### PR TITLE
[Day006]: Wrong syntax on MD table

### DIFF
--- a/Day006-Attribute-Directive-Class-Style.md
+++ b/Day006-Attribute-Directive-Class-Style.md
@@ -55,11 +55,11 @@ Cuối cùng là cú pháp dạng:
 
 Với styleExpr là một trong các dạng:
 
-| Type         | Value                                                                              |
-| ------------ | ---------------------------------------------------------------------------------- |
-| String       | `"width: 100%; height: 100%"`                                                      |
-| Array String | `['width', '100px']`                                                               |
-| Object       | `{[key: string]: string | undefined | null} như {width: '100px', height: '100px'}` |
+| Type         | Value                                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| String       | `"width: 100%; height: 100%"`                                                                           |
+| Array String | `['width', '100px']`                                                                                    |
+| Object       | <code>{[key: string]: string &#x7c; undefined &#x7c; null} như {width: '100px', height: '100px'}</code> |
 
 Có một directive tương tự là ngStyle với cách dùng gấn giống thế, trong hầu hết các trường hợp, chúng ta được khuyến cáo sử dụng style binding thay thế.
 Lưu ý rằng, một style property có thể dùng cả kiểu dash-key hoặc camelCase, ví dụ font-size hoặc fontSize đều được.


### PR DESCRIPTION
### Expected result
<img width="872" alt="image" src="https://user-images.githubusercontent.com/54234094/111022717-11035280-8407-11eb-90f8-90cfd7569093.png">

### Actual result
<img width="452" alt="image" src="https://user-images.githubusercontent.com/54234094/111022688-ea451c00-8406-11eb-99f1-0ac930007c93.png">



https://stackoverflow.com/questions/17319940/how-to-escape-a-pipe-char-in-a-code-statement-in-a-markdown-table